### PR TITLE
Add in JUPYTER_TOKEN Variable to Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - 8888:8888
     volumes:
       - base_volume:/project
+    environment:
+      JUPYTER_TOKEN: "secret_here"
 volumes:
   base_volume:
     external: true


### PR DESCRIPTION
Create a token variable to maintain a single link for each container running Jupyter Lab.